### PR TITLE
fix: list required scopes in cimd.json

### DIFF
--- a/examples/oauth/cimd.json
+++ b/examples/oauth/cimd.json
@@ -4,6 +4,7 @@
   "redirect_uris": [
     "https://swicg.github.io/activitypub-api/examples/oauth/index.html"
   ],
+  "scope": "read write",
   "token_endpoint_auth_method": "none",
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],


### PR DESCRIPTION
This prevents errors caused by the client requesting scopes that weren't previously listed in its registration.
